### PR TITLE
Add force stack alignment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ endif
 ELF  := elfldr.elf
 BIN  := elfldr.bin
 
-CFLAGS := -fPIC -Wall -Werror -g
+CFLAGS := -fPIC -Wall -Werror -g -mstackrealign
 
 SRCS := $(wildcard *.c)
 SRCS += $(wildcard *.h)


### PR DESCRIPTION
- Adds -mstackrealign to the CFLAGS

Fixes an issue with the stack being misaligned when the main was called in bootstrap-elf.c specifically when I loaded from the web browser bin loader.